### PR TITLE
Fixing problem with labels in inluded papers.

### DIFF
--- a/TemplateFiles/AddMyPapers.sty
+++ b/TemplateFiles/AddMyPapers.sty
@@ -45,8 +45,8 @@
 	% to different things. If one wants to refer to
 	% something inside of an appended paper from outside,
 	% then <PaperName>: need to be appended when using \ref.
-	\renewcommand{\label}[1]{\oldlabel{\LabelPrefix:#1}}
-	\renewcommand{\ref}[1]{\oldref{\LabelPrefix:#1}}
+	\renewcommand{\label}[1]{\oldlabel{\LabelPrefix:##1}}
+	\renewcommand{\ref}[1]{\oldref{\LabelPrefix:##1}}
     \input{YourThesis/papers/#1/content.tex}
     \printbibliography[heading=secbib]
     % Restore \label and \ref to old meaning.


### PR DESCRIPTION
Parameters in new commands in new environments need double pound to defer the correct parameter. This should fix problems with multiply defined labels.